### PR TITLE
🎨 Dry button name

### DIFF
--- a/src/lib/organisms/methodHeader.svelte
+++ b/src/lib/organisms/methodHeader.svelte
@@ -26,7 +26,7 @@
         </li>
 
         {#if method.pdf}
-          <a href="{method.pdf.url}" download="{method.slug}.pdf" target="blank" class="button-pdf">Download</a>
+        <a href="{method.pdf.url}" download="{method.slug}.pdf" target="blank" class="vt-standard-button">Download</a>
         {/if}
       
     </ul>
@@ -88,17 +88,16 @@
     font-weight: 100;
   }
 
-  .button-pdf {
+  .vt-standard-button {
 	  color: white;
 	  font-family: var(--vtPrimaryFont);
 	  background-color: var(--vtDarkBlue);
-    padding: 0.5em 0.4em ;
-	  border-radius: 0.2em;
+    padding: 1em 0.5em;
+	  border-radius: 2em;
 	  margin-left: 1em;
-    margin-bottom: 0.5em;
 	}
   
-	:hover .button-pdf {
+	:hover .vt-standard-button {
 	  color: var(--vtDarkBlue);
 	  background-color: rgb(188, 188, 188);
 	}


### PR DESCRIPTION
## What does this change?

Resolves issue #158 

This PR changes the old button name to a new better and dryer name, which we now can re-use.
- Button-pdf > vt-standard-button

[livesite]( https://visual-thinking-k1e8.vercel.app/)

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

This is what the button name looks like now. 

![image](https://github.com/fdnd-agency/visual-thinking/assets/112856683/f124da39-3ce9-448a-9904-56593a57e832)


## How to review

If you’re working in the code, you can find the new name in the methodHeader.svelte file.
