### PR TITLE
🐛Removed spacing header

### DIFF
--- a/src/lib/organisms/methodHeader.svelte
+++ b/src/lib/organisms/methodHeader.svelte
@@ -35,7 +35,8 @@
 
 <style>
   header {
-    margin:0 -1rem 1rem;
+    margin:0 -1rem;
+    margin-top: -0.3em;
     background-color: var(--vtGrey-10);
   }
 


### PR DESCRIPTION
## What does this change?

Resolves issue #157

I removed the spacing between the header of the methods page and the breadcrumb.

[livesite](https://livesite.com)

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [x] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

**Before**
![image](https://github.com/fdnd-agency/visual-thinking/assets/112856683/69c01776-78f7-4a03-840d-3619eb9b96b3)

**After**
![image](https://github.com/fdnd-agency/visual-thinking/assets/112856683/291103dc-0aca-477d-93e4-1f6cd6787258)


## How to review

Go to the methods page > choose a method > here you will see the breadcrumb above the header. It now doesn't have spacing between them anymore.
