### PR TITLE
♻️Refactored background-color breadcrumb

### DIFF
--- a/src/routes/artikelen/+page.svelte
+++ b/src/routes/artikelen/+page.svelte
@@ -8,6 +8,6 @@
   const {page, articles} = data
 </script>
 
-<Breadcrumb titel="Artikelen" bgc="var(--vtSec-DarkBlue)" />
+<Breadcrumb titel="Artikelen" bgc="var(--vtDarkBlue)" />
 <Introduction data={page}/>
 <Articles data={articles}/>


### PR DESCRIPTION
## What does this change?

Resolves issue #156 

I changed the background color of the breadcrumb on the articles page. It first was the secondary blue color, but it had to be the main blue color.

[livesite](https://livesite.com)

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [x] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

**Before**
![image](https://github.com/fdnd-agency/visual-thinking/assets/112856683/e8545300-24cd-43b1-abe0-0e01579e73f1)

**After** 
![image](https://github.com/fdnd-agency/visual-thinking/assets/112856683/d95a345c-4341-442a-92b4-f9e438e5faf4)


## How to review

Click on 'artikelen' in the header or navigation. On the top of the screen, you will see the new dark blue breadcrumb.
