### PR TITLE
💄 Link styling articles

### DIFF
--- a/static/styles/global.css
+++ b/static/styles/global.css
@@ -86,6 +86,11 @@ blockquote {
   font-style: italic;
 }
 
+.link {
+  text-decoration: underline;
+  text-decoration-color:var(--vtDarkBlue);
+}
+
 h1,
 h2,
 h3 {


### PR DESCRIPTION
## What does this change?

The links on the article pages were not visible. I added some styling to the links and gave classes in Hygraph to the links.

You can find the classes in Hygraph when you follow these steps:

1. Go to an article.
2. Search a link (blue link in hygraph).
3. Select the link.
4. Click on the link icon.
5. Go to the attributes page.
6. Add or change class.

Resolves issue #120 


[livesite](https://livesite.com)

## How Has This Been Tested?

- [x] User test
- [ ] Accessibility test
- [x] Performance test
- [x] Responsive Design test
- [x] Device test
- [ ] Browser test

## Images

**Before**

![image](https://github.com/fdnd-agency/visual-thinking/assets/112856683/601fecd2-f236-4bb1-8a0d-43fc304dacd5)


**After**

![image](https://github.com/fdnd-agency/visual-thinking/assets/112856683/8f4dbb3c-8919-4cc1-91fa-ee7cc88bea58)


## How to review

Go to the articles page. When scrolling you will find some links with a dark underline.
