### PR TITLE
🐛 Data ophalen methods error

### DIFF
--- a/src/lib/organisms/methodHeader.svelte
+++ b/src/lib/organisms/methodHeader.svelte
@@ -1,6 +1,7 @@
 <script>
   export let data;
-  const method = data.method
+  const method = data.methods[0]
+  console.log(data);
 </script>
 
 <header>

--- a/src/lib/queries/method.js
+++ b/src/lib/queries/method.js
@@ -1,7 +1,7 @@
 export default function methodDescriptionQuery(gql, slug) {
     return gql`
       query VisualThinking {
-        method(where: { slug: "${slug}" }) {
+        methods(where: { slug: "${slug}" }) {
           title
           slug
           id

--- a/src/routes/tekenmethodes/[slug]/+page.svelte
+++ b/src/routes/tekenmethodes/[slug]/+page.svelte
@@ -14,11 +14,14 @@
 <MethodHeader {data} />
 
 <section class="section-wrapper">
-  <img src={data.method?.template?.url} alt="template_image" loading="lazy" />
+  {#each data.methods as method}
+    <img src={method?.template?.url} alt="template_image" loading="lazy" />
 
   <p>
-    {@html data.method?.description.html}
+    {@html method?.description.html}
   </p>
+  {/each}
+ 
 </section>
 
 
@@ -48,7 +51,5 @@
       justify-content: center;
     }
   }
-
- 
 
 </style>


### PR DESCRIPTION
## What does this change?

There was a bug on the methods page. The steps and examples pages did not work anymore. It probably happend in an old commit, so I looked back at the commits and reversed some code.

## How Has This Been Tested?

- [x] User test
- [ ] Accessibility test
- [ ] Performance test
- [x] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

**Before**

![image](https://github.com/fdnd-agency/visual-thinking/assets/112856683/4348c882-6d63-4eb8-aa8c-698345fcb190)


**After**

![image](https://github.com/fdnd-agency/visual-thinking/assets/112856683/b670ad7c-a842-4165-a8f8-73de437e5ca5)


## How to review

When on the visual thinking website, click on 'tekenmethodes' and go to a random method. Here you click on 'stappenplan' or 'Voorbeelden'.
