### PR TITLE
:lipstick:  Quotes styling

### DIFF
--- a/src/routes/artikelen/+page.svelte
+++ b/src/routes/artikelen/+page.svelte
@@ -11,3 +11,5 @@
 <Breadcrumb titel="Artikelen" bgc="var(--vtSec-DarkBlue)" />
 <Introduction data={page}/>
 <Articles data={articles}/>
+
+

--- a/src/routes/artikelen/[slug]/+page.svelte
+++ b/src/routes/artikelen/[slug]/+page.svelte
@@ -78,6 +78,9 @@
     font-weight: bold;
   }
 
+
+  
+
   /* tablet */
   @media (min-width: 50em) {
     header {

--- a/static/styles/global.css
+++ b/static/styles/global.css
@@ -96,12 +96,6 @@ blockquote {
   color: #625c51;
 }
 
-.minicursus-quotes:after {
-  content: "”";
-  right: -5rem;
-  bottom: -0.4rem;
-}
-
 blockquote:before,
 blockquote:after {
   position: absolute;

--- a/static/styles/global.css
+++ b/static/styles/global.css
@@ -80,10 +80,52 @@ body {
 }
 
 blockquote {
-  color: var(--vtYellow);
+  font-weight: 800;
   font-family: var(--vtPrimaryFont);
-  margin: 0 0 1rem;
-  font-style: italic;
+  font-size: 1.2rem;
+  line-height: 1.5;
+  position: relative;
+  color: #625c51;
+}
+
+.minicursus-quotes {
+  font-weight: 800;
+  font-family: var(--vtPrimaryFont);
+  font-size: 1.2rem;
+  line-height: 1.5;
+  color: #625c51;
+}
+
+.minicursus-quotes:after {
+  content: "”";
+  right: -5rem;
+  bottom: -0.4rem;
+}
+
+blockquote:before,
+blockquote:after {
+  position: absolute;
+  color: var(--vtYellow);
+  font-size: 6rem;
+  width: 4rem;
+  height: 4rem;
+}
+
+blockquote:before {
+  content: "“";
+  left: -5rem;
+  top: -3rem;
+}
+
+blockquote:after {
+  content: "”";
+  right: -5rem;
+  bottom: -0.4rem;
+}
+
+.cite {
+  font-family: var(--vtSecondaryFont);
+  color: #625c51;
 }
 
 h1,
@@ -122,8 +164,8 @@ img {
 }
 
 ul {
-  align-self:flex-start;
-  scrollbar-width:none;
+  align-self: flex-start;
+  scrollbar-width: none;
 }
 
 ul::-webkit-scrollbar {
@@ -147,28 +189,28 @@ main {
 
 /* rich text data styling*/
 .rich-text img {
-  height:auto;
+  height: auto;
 }
 
 /* svg icons */
 svg.icon {
-  margin-right: .25rem;
+  margin-right: 0.25rem;
 }
 svg.icon path {
-  fill:var(--vtDarkBlue)
+  fill: var(--vtDarkBlue);
 }
 svg.icon path.background {
-  fill:var(--vtGrey-50)
+  fill: var(--vtGrey-50);
 }
 
 /* hexagon stuff (work in progress) */
 .hexagons header {
-  display:flex;
-  flex-direction:column;
+  display: flex;
+  flex-direction: column;
   align-items: center;
 }
 .hexagons h1 {
-  max-width:24rem;
+  max-width: 24rem;
 }
 .hexagons p {
   text-align: center;
@@ -176,6 +218,6 @@ svg.icon path.background {
 
 @media (width > 70em) {
   .hexagons p {
-    max-width:12rem;
+    max-width: 12rem;
   }
 }


### PR DESCRIPTION
## What does this change?

I have added the blockquote styling for two separate pages: the Articles page and the Mini Courses page.

Resolves issue #119 #60 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite]((https://visual-thinking-three.vercel.app/)

## How Has This Been Tested?

- [X] User test
- [X] Responsive Design test
- [X] Browser test

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

> <img width="877" alt="Scherm­afbeelding 2024-06-12 om 13 18 08" src="https://github.com/fdnd-agency/visual-thinking/assets/112857932/f4316a21-347e-46f5-a1a8-19004895c9e4">
- _Artikelen page_

>  <img width="877" alt="Scherm­afbeelding 2024-06-12 om 13 21 11" src="https://github.com/fdnd-agency/visual-thinking/assets/112857932/2b0bb3c7-c6be-4a38-8888-c327f3427cce">
- _Minicursussen page_

## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Code/design Check
