### PR TITLE
Bug hexagons positionering

### DIFF
--- a/src/lib/molecules/introduction.svelte
+++ b/src/lib/molecules/introduction.svelte
@@ -21,7 +21,6 @@
       font-size: 1.7rem;
   }
   @media screen and (min-width: 36em) {
-
     header {
       width: 75%;
     }
@@ -30,7 +29,9 @@
       font-size: 3.157rem;
       text-align: center;
     }
+  }
 
+  @media screen and (min-width: 70em) {
     /* Hexagons positionering */
     :global(main) {
       position: relative;

--- a/src/lib/molecules/introduction.svelte
+++ b/src/lib/molecules/introduction.svelte
@@ -4,6 +4,7 @@
   const {title, content} = data
 </script>
 
+
 <header>
   <h1>{title}</h1>
     
@@ -20,12 +21,20 @@
       font-size: 1.7rem;
   }
   @media screen and (min-width: 36em) {
-      header {
-          width: 75%;
-      }
-      h1 {
-          font-size: 3.157rem;
-          text-align: center;
-      }
+    :global(main) {
+      position: relative;
+    }
+    header {
+      width: 75%;
+      /* background-color: blue; */
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 0;
+    }
+    h1 {
+      font-size: 3.157rem;
+      text-align: center;
+    }
   }
 </style>

--- a/src/lib/molecules/introduction.svelte
+++ b/src/lib/molecules/introduction.svelte
@@ -21,20 +21,30 @@
       font-size: 1.7rem;
   }
   @media screen and (min-width: 36em) {
+
+    header {
+      width: 75%;
+    }
+
+    h1 {
+      font-size: 3.157rem;
+      text-align: center;
+    }
+
+    /* Hexagons positionering */
     :global(main) {
       position: relative;
     }
-    header {
-      width: 75%;
-      /* background-color: blue; */
+
+    :global(.hexagons header) {
       position: absolute;
       left: 0;
       right: 0;
       top: 0;
     }
-    h1 {
-      font-size: 3.157rem;
-      text-align: center;
+
+    :global(.minicourse header) {
+      top: 1.2rem; /* Breadcrum height */
     }
   }
 </style>

--- a/src/lib/organisms/homepage.svelte
+++ b/src/lib/organisms/homepage.svelte
@@ -246,7 +246,6 @@
 
       --cc: 4;
       --rc: 2;
-      margin-top: -60vh;
     }
 
     ul li:nth-of-type(1) {

--- a/src/lib/organisms/miniCourses.svelte
+++ b/src/lib/organisms/miniCourses.svelte
@@ -85,7 +85,7 @@
     }
   }
 
-  @media (width > 60em) {
+  @media (width > 70em) {
     ul {
       --gap: 2rem;
       --size: 14em;

--- a/src/lib/organisms/miniCourses.svelte
+++ b/src/lib/organisms/miniCourses.svelte
@@ -95,7 +95,7 @@
 
       --cc: 4;
       --rc: 2;
-      /* margin-top: 2em; */
+      margin-top: calc(1.2rem + 3.157em); /* breadcrumheight + h1 height */
     }
     
     ul li a:hover {

--- a/src/lib/organisms/miniCourses.svelte
+++ b/src/lib/organisms/miniCourses.svelte
@@ -78,7 +78,7 @@
     place-self: center;
   }
 
-  @media (width > 35rem) {
+  @media (width > 36rem) {
     ul {
       --rc: 2;
       --cc: 2;
@@ -95,7 +95,7 @@
 
       --cc: 4;
       --rc: 2;
-      margin-top: -28vh;
+      /* margin-top: 2em; */
     }
     
     ul li a:hover {

--- a/src/routes/minicursussen/+page.svelte
+++ b/src/routes/minicursussen/+page.svelte
@@ -10,7 +10,7 @@
 
 <Breadcrumb titel="Minicursussen" bgc="var(--vtRed)" />
 
-<div class="hexagons">
+<div class="hexagons minicourse">
   <Introduction data={page}/>
   <MiniCourses data={miniCourses} />
 </div>


### PR DESCRIPTION
## What does this change?
Fixed a bug where the hexagons are positioned weirdly when the window is too long or too short (see images below). This is because the components that have the hexagons (hompage.svelte, miniCourses.svelte) had a 'margin top: 60vh;'. 

The 'vh' unit made the positioning so weird.

I solved this by making the introduction component at the hexagons position absolute so that the hexagons are on top of the introduction (see commits for clarification). 

!! I don't know if this is the best solution, because using position absolute isn't the best idea, but it does work. 
I also thought about perhaps removing the introduction text from the introduction component and putting it in the homepage/miniCourse components so that it becomes 1 with the hexagons and then changing the 'order' of the grid for the tablet/mobile version, but this is a faster way :)

Resolves issue #248 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board.  

[livesite](https://livesite.com) -->

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [x] Responsive Design test
- [ ] Device test
- [x] Browser test

### Responsive Design test
#### Before
> Er was een fout bij de responsiveheid van de tablet versie van de minicursus pagina:

<details>
<summary>Screenshot tablet bug</summary>

![Schermafbeelding 2025-01-09 235735](https://github.com/user-attachments/assets/40c9fd20-694d-46cf-90ae-0557884736a8)

</details>

#### After
See commit [Responsiveness hexagons v1](https://github.com/fdnd-agency/visual-thinking/commit/61ced0fda0a4163838f6c2ade4fd9476b3373c34) for solution

<details>
<summary>Screenshot desktop, tablet, mobile</summary>
Desktop

![Schermafbeelding 2025-01-10 000513](https://github.com/user-attachments/assets/4f7048a3-2039-4cdc-8d27-c9f108375985)

Tablet

![Schermafbeelding 2025-01-10 000522](https://github.com/user-attachments/assets/8aa665bf-f59c-4974-906d-aefa2080e389)

Mobile


![Schermafbeelding 2025-01-10 000531](https://github.com/user-attachments/assets/934b194b-0621-4c18-b0b3-8f165a360898)

</details>

### Browser test
> The following browsers have been tested: Chrome, Firefox, Edge, Safari


<details>
<summary>Browser test screenshots</summary>

Chrome
![Schermafbeelding 2025-01-10 001348](https://github.com/user-attachments/assets/86b6d329-3c0d-4c8f-ae14-0e1d9e8fe620)

![Schermafbeelding 2025-01-10 001343](https://github.com/user-attachments/assets/acc39d8d-053d-46a4-912b-e6b5db0e9e0a)


Firefox

![Schermafbeelding 2025-01-09 233858](https://github.com/user-attachments/assets/5d7723be-50b0-4aba-8ce5-8981da67d451)

![Schermafbeelding 2025-01-09 233915](https://github.com/user-attachments/assets/9769cb33-09e6-4b5d-8ad1-032566481547)

Edge

![Schermafbeelding 2025-01-09 233949](https://github.com/user-attachments/assets/462f7061-cf60-4c19-8c29-8edb2fe6f2dc)

![Schermafbeelding 2025-01-09 234003](https://github.com/user-attachments/assets/bc4e8b99-5f99-4faa-ace2-6918c0f2d61d)

Safari

![IMG_0997](https://github.com/user-attachments/assets/14acf384-2582-4a18-9387-5a7cf56bc24c)

![IMG_0998](https://github.com/user-attachments/assets/2c09f7ee-6a6d-4b56-93d1-1d44b1ae2a15)

</details>

#### Conclusion
There is no difference. Only the colors of the hexagons are more grey in the Edge version.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
### Before
Homepage
![Schermafbeelding 2025-01-07 143231](https://github.com/user-attachments/assets/1743f340-9fbf-428a-8216-a950308376f6)

> When the window was larger then expected, the hexagons where opperating weirdly

MiniCourses
![Schermafbeelding 2025-01-09 233400](https://github.com/user-attachments/assets/ff1d0420-ece8-4949-9877-b0ba693f39f8)

> The same thing happens when the window was shorter then expected for bothe the homepage and minicursusus page.

### After
Homepage
![Schermafbeelding 2025-01-10 001348](https://github.com/user-attachments/assets/dd512d27-ad39-4402-a21a-0f9fa3e0b850)

MiniCourse
![Schermafbeelding 2025-01-10 001343](https://github.com/user-attachments/assets/8ead2403-ebf9-4bd7-aef8-be023d533239)


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

The changes where made in the introduction.svelte, homepage.svelte and miniCourses.svelte components in de `width > 70em` media query. 

!! See commits for more info


