### PR TITLE
Methods max width

### DIFF
--- a/src/lib/molecules/Filter.svelte
+++ b/src/lib/molecules/Filter.svelte
@@ -52,7 +52,7 @@
 
 <style>
   section {
-    max-width: 40rem;
+    max-width: var(--grid-max-width);
     margin: auto;
     margin-bottom: 2rem;
   }

--- a/src/lib/molecules/Filter.svelte
+++ b/src/lib/molecules/Filter.svelte
@@ -51,6 +51,12 @@
 </section>
 
 <style>
+  section {
+    max-width: 40rem;
+    margin: auto;
+    margin-bottom: 2rem;
+  }
+
   h2 {
     font-size: 1rem;
     padding: 1rem;

--- a/src/lib/molecules/Introduction.svelte
+++ b/src/lib/molecules/Introduction.svelte
@@ -1,31 +1,31 @@
 <script>
   export let page;
 
-  const {title, content} = page;
+  const { title, content } = page;
 </script>
 
 <section>
   <h1>{title}</h1>
-    
+
   {@html content.html}
 </section>
 
 <style>
   section {
-      max-width: 40rem;
-      margin: 0 auto 2rem;
+    max-width: var(--page-max-width);
+    margin: 0 auto 2rem auto;
   }
 
   h1 {
-      font-size: 1.7rem;
+    font-size: 1.7rem;
   }
   @media screen and (min-width: 36rem) {
-      section {
-          width: 75%;
-      }
-      h1 {
-          font-size: 3.157rem;
-          text-align: center;
-      }
+    section {
+      width: 75%;
+    }
+    h1 {
+      font-size: 3.157rem;
+      text-align: center;
+    }
   }
 </style>

--- a/src/lib/molecules/Introduction.svelte
+++ b/src/lib/molecules/Introduction.svelte
@@ -12,7 +12,7 @@
 
 <style>
   section {
-    max-width: var(--page-max-width);
+    max-width: var(--text-max-width);
     margin: 0 auto 2rem auto;
   }
 

--- a/src/lib/molecules/filter.svelte
+++ b/src/lib/molecules/filter.svelte
@@ -52,7 +52,7 @@
 
 <style>
   section {
-    max-width: 40rem;
+    max-width: var(--grid-max-width);
     margin: auto;
     margin-bottom: 2rem;
   }

--- a/src/lib/molecules/filter.svelte
+++ b/src/lib/molecules/filter.svelte
@@ -51,6 +51,12 @@
 </section>
 
 <style>
+  section {
+    max-width: 40rem;
+    margin: auto;
+    margin-bottom: 2rem;
+  }
+
   h2 {
     font-size: 1rem;
     padding: 1rem;

--- a/src/lib/molecules/introduction.svelte
+++ b/src/lib/molecules/introduction.svelte
@@ -1,31 +1,31 @@
 <script>
   export let page;
 
-  const {title, content} = page;
+  const { title, content } = page;
 </script>
 
 <section>
   <h1>{title}</h1>
-    
+
   {@html content.html}
 </section>
 
 <style>
   section {
-      max-width: 40rem;
-      margin: 0 auto 2rem;
+    max-width: var(--page-max-width);
+    margin: 0 auto 2rem auto;
   }
 
   h1 {
-      font-size: 1.7rem;
+    font-size: 1.7rem;
   }
   @media screen and (min-width: 36rem) {
-      section {
-          width: 75%;
-      }
-      h1 {
-          font-size: 3.157rem;
-          text-align: center;
-      }
+    section {
+      width: 75%;
+    }
+    h1 {
+      font-size: 3.157rem;
+      text-align: center;
+    }
   }
 </style>

--- a/src/lib/molecules/introduction.svelte
+++ b/src/lib/molecules/introduction.svelte
@@ -12,7 +12,7 @@
 
 <style>
   section {
-    max-width: var(--page-max-width);
+    max-width: var(--text-max-width);
     margin: 0 auto 2rem auto;
   }
 

--- a/src/lib/organisms/Articles.svelte
+++ b/src/lib/organisms/Articles.svelte
@@ -25,6 +25,8 @@
     justify-items: stretch;
     padding: 2rem 0;
     gap: 0.5rem;
+    max-width: var(--page-max-width);
+    margin: auto;
   }
 
   a {

--- a/src/lib/organisms/Articles.svelte
+++ b/src/lib/organisms/Articles.svelte
@@ -21,7 +21,7 @@
 <style>
   .grid {
     display: grid;
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     justify-items: stretch;
     padding: 2rem 0;
     gap: 0.5rem;
@@ -44,7 +44,7 @@
   }
 
   article {
-    padding: 3rem;
+    padding: 1rem;
     display: flex;
     flex-direction: column;
   }
@@ -63,18 +63,5 @@
     text-wrap: balance;
   }
 
-  /* TABLET - STYLING */
-  @media screen and (min-width: 36rem) {
-    .grid {
-      grid-template-columns: repeat(2, 1fr);
-      margin: 2rem auto;
-    }
-  }
-
-  /* DESKTOP - STYLING */
-  @media screen and (min-width: 60rem) {
-    .grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
+ 
 </style>

--- a/src/lib/organisms/Articles.svelte
+++ b/src/lib/organisms/Articles.svelte
@@ -21,11 +21,11 @@
 <style>
   .grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     justify-items: stretch;
     padding: 2rem 0;
     gap: 0.5rem;
-    max-width: var(--page-max-width);
+    max-width: var(--grid-max-width);
     margin: auto;
   }
 

--- a/src/lib/organisms/Methods.svelte
+++ b/src/lib/organisms/Methods.svelte
@@ -33,7 +33,8 @@
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: 1.5rem;
     margin: 1rem 0;
-    max-width: 40rem;
+    max-width: var(--page-max-width);
+    margin: auto;
   }
 
   h2 {

--- a/src/lib/organisms/Methods.svelte
+++ b/src/lib/organisms/Methods.svelte
@@ -30,9 +30,10 @@
 <style>
   .grid {
     display: grid;
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: 1.5rem;
     margin: 1rem 0;
+    max-width: 40rem;
   }
 
   h2 {
@@ -71,17 +72,5 @@
   article:hover {
     border-bottom: 0.3rem solid var(--vtYellow);
     background-color: var(--vtGrey-10);
-  }
-
-  @media screen and (min-width: 36rem) {
-    .grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-
-  @media screen and (min-width: 60rem) {
-    .grid {
-      grid-template-columns: repeat(3, 1fr);
-    }
   }
 </style>

--- a/src/lib/organisms/Methods.svelte
+++ b/src/lib/organisms/Methods.svelte
@@ -48,6 +48,8 @@
     font-weight: 400;
     margin: 0;
     width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   a {

--- a/src/lib/organisms/Methods.svelte
+++ b/src/lib/organisms/Methods.svelte
@@ -30,10 +30,10 @@
 <style>
   .grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: 1.5rem;
     margin: 1rem 0;
-    max-width: var(--page-max-width);
+    max-width: var(--grid-max-width);
     margin: auto;
   }
 

--- a/src/lib/organisms/Methods.svelte
+++ b/src/lib/organisms/Methods.svelte
@@ -20,8 +20,8 @@
           {:else}
             <img src="/placeholder.webp" alt="Placeholder" />
           {/if}
+          <h3>{method.title}</h3>
         </a>
-        <h3>{method.title}</h3>
       </article>
     {/each}
   {/if}
@@ -51,14 +51,13 @@
   a {
     text-decoration: none;
     color: var(--vtBlack);
+    padding: 0.8rem 0.8rem 0.25rem 0.8rem;
   }
 
   article {
     display: flex;
     flex-direction: column;
     transition: 0.1s;
-    padding: 0.8rem;
-    padding-bottom: 0.25rem;
     margin: -0.8rem;
     border-bottom: 0.3rem solid transparent;
   }

--- a/src/lib/organisms/articles.svelte
+++ b/src/lib/organisms/articles.svelte
@@ -25,6 +25,8 @@
     justify-items: stretch;
     padding: 2rem 0;
     gap: 0.5rem;
+    max-width: var(--page-max-width);
+    margin: auto;
   }
 
   a {

--- a/src/lib/organisms/articles.svelte
+++ b/src/lib/organisms/articles.svelte
@@ -21,7 +21,7 @@
 <style>
   .grid {
     display: grid;
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     justify-items: stretch;
     padding: 2rem 0;
     gap: 0.5rem;
@@ -44,7 +44,7 @@
   }
 
   article {
-    padding: 3rem;
+    padding: 1rem;
     display: flex;
     flex-direction: column;
   }
@@ -63,18 +63,5 @@
     text-wrap: balance;
   }
 
-  /* TABLET - STYLING */
-  @media screen and (min-width: 36rem) {
-    .grid {
-      grid-template-columns: repeat(2, 1fr);
-      margin: 2rem auto;
-    }
-  }
-
-  /* DESKTOP - STYLING */
-  @media screen and (min-width: 60rem) {
-    .grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
+ 
 </style>

--- a/src/lib/organisms/articles.svelte
+++ b/src/lib/organisms/articles.svelte
@@ -21,11 +21,11 @@
 <style>
   .grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     justify-items: stretch;
     padding: 2rem 0;
     gap: 0.5rem;
-    max-width: var(--page-max-width);
+    max-width: var(--grid-max-width);
     margin: auto;
   }
 

--- a/src/lib/organisms/methods.svelte
+++ b/src/lib/organisms/methods.svelte
@@ -33,7 +33,8 @@
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: 1.5rem;
     margin: 1rem 0;
-    max-width: 40rem;
+    max-width: var(--page-max-width);
+    margin: auto;
   }
 
   h2 {

--- a/src/lib/organisms/methods.svelte
+++ b/src/lib/organisms/methods.svelte
@@ -30,9 +30,10 @@
 <style>
   .grid {
     display: grid;
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: 1.5rem;
     margin: 1rem 0;
+    max-width: 40rem;
   }
 
   h2 {
@@ -71,17 +72,5 @@
   article:hover {
     border-bottom: 0.3rem solid var(--vtYellow);
     background-color: var(--vtGrey-10);
-  }
-
-  @media screen and (min-width: 36rem) {
-    .grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-
-  @media screen and (min-width: 60rem) {
-    .grid {
-      grid-template-columns: repeat(3, 1fr);
-    }
   }
 </style>

--- a/src/lib/organisms/methods.svelte
+++ b/src/lib/organisms/methods.svelte
@@ -48,6 +48,8 @@
     font-weight: 400;
     margin: 0;
     width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   a {

--- a/src/lib/organisms/methods.svelte
+++ b/src/lib/organisms/methods.svelte
@@ -30,10 +30,10 @@
 <style>
   .grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: 1.5rem;
     margin: 1rem 0;
-    max-width: var(--page-max-width);
+    max-width: var(--grid-max-width);
     margin: auto;
   }
 

--- a/src/lib/organisms/methods.svelte
+++ b/src/lib/organisms/methods.svelte
@@ -20,8 +20,8 @@
           {:else}
             <img src="/placeholder.webp" alt="Placeholder" />
           {/if}
+          <h3>{method.title}</h3>
         </a>
-        <h3>{method.title}</h3>
       </article>
     {/each}
   {/if}
@@ -51,14 +51,13 @@
   a {
     text-decoration: none;
     color: var(--vtBlack);
+    padding: 0.8rem 0.8rem 0.25rem 0.8rem;
   }
 
   article {
     display: flex;
     flex-direction: column;
     transition: 0.1s;
-    padding: 0.8rem;
-    padding-bottom: 0.25rem;
     margin: -0.8rem;
     border-bottom: 0.3rem solid transparent;
   }

--- a/static/styles/global.css
+++ b/static/styles/global.css
@@ -73,6 +73,9 @@
   /* Fonts */
   font-size: 20px;
   --SecFont: 1.7rem;
+
+  /* Max width of page contents */
+  --page-max-width: 40rem;
 }
 
 /* Basis styling */

--- a/static/styles/global.css
+++ b/static/styles/global.css
@@ -75,7 +75,8 @@
   --SecFont: 1.7rem;
 
   /* Max width of page contents */
-  --page-max-width: 40rem;
+  --text-max-width: 40rem;
+  --grid-max-width: 60rem;
 }
 
 /* Basis styling */


### PR DESCRIPTION
# Description
Added a max width variable in the `global.css` for page contents, and applied these to the components `Introduction`, `Filter`, `Methods` and `Articles`. This makes it easier to add a max width to pages, and now there is a max width on the grids on the Articles and the Methods pages. 

In the process, I also refactored the CSS for the grids on both of these pages, making them more responsive. This also fixes a previous bug where the grid columns would not resize properly.

### Before
![image](https://github.com/user-attachments/assets/e9349db9-5b06-41e6-9765-11c3b1933f2b)

### After
![image](https://github.com/user-attachments/assets/2130ac1e-c7d9-419e-a052-e7016d10cba4)

Fixes [#189](https://github.com/fdnd-agency/visual-thinking/issues/189) [#227](https://github.com/fdnd-agency/visual-thinking/issues/227)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [ ] Performance test
- [x] Responsive Design test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] The code is accessible
- [x] The code is performant
- [x] The code is responsive
- [x] I have written meaningful commit messages
- [x] I have performed a self-review of my code



