### PR TITLE
Hexagons focus state bug

### DIFF
--- a/src/lib/atoms/Hexagon.svelte
+++ b/src/lib/atoms/Hexagon.svelte
@@ -68,7 +68,9 @@
     text-align: center;
   }
 
-  .hover:hover {
+  .hover:hover,
+  .hover:focus-visible {
     transform: scale(1.05);
+    outline: unset;
   }
 </style>

--- a/src/lib/organisms/Homepage.svelte
+++ b/src/lib/organisms/Homepage.svelte
@@ -47,18 +47,18 @@
     </li>
     <li>
       <Hexagon
-        href="/kennisclips"
-        backgroundColor="--vtLightBlue"
-        color="--vtWhite"
-        text="Kennisclips"
-      />
-    </li>
-    <li>
-      <Hexagon
         href="/minicursussen"
         backgroundColor="--vtRed"
         color="--vtWhite"
         text="Minicursussen"
+      />
+    </li>
+    <li>
+      <Hexagon
+        href="/kennisclips"
+        backgroundColor="--vtLightBlue"
+        color="--vtWhite"
+        text="Kennisclips"
       />
     </li>
     <li>
@@ -266,13 +266,13 @@
       transform: translateX(0);
     }
 
-    ul li:nth-of-type(6) {
+    ul li:nth-of-type(7) {
       grid-column-start: 3;
       grid-row-start: 3;
       transform: translateX(0);
     }
 
-    ul li:nth-of-type(7) {
+    ul li:nth-of-type(6) {
       grid-column-start: 2;
       grid-row-start: 3;
       transform: translateX(0);
@@ -283,7 +283,5 @@
       grid-row-start: 3;
       transform: translateX(0);
     }
-
-   
   }
 </style>

--- a/src/lib/organisms/MiniCourses.svelte
+++ b/src/lib/organisms/MiniCourses.svelte
@@ -69,7 +69,7 @@
   }
 
   ul li:nth-of-type(4) {
-    --background-color: var(--vtDarkBlue);
+    --background-color: var(--vtSec-DarkBlue);
   }
 
   @media (width > 36rem) {

--- a/src/lib/organisms/homepage.svelte
+++ b/src/lib/organisms/homepage.svelte
@@ -47,18 +47,18 @@
     </li>
     <li>
       <Hexagon
-        href="/kennisclips"
-        backgroundColor="--vtLightBlue"
-        color="--vtWhite"
-        text="Kennisclips"
-      />
-    </li>
-    <li>
-      <Hexagon
         href="/minicursussen"
         backgroundColor="--vtRed"
         color="--vtWhite"
         text="Minicursussen"
+      />
+    </li>
+    <li>
+      <Hexagon
+        href="/kennisclips"
+        backgroundColor="--vtLightBlue"
+        color="--vtWhite"
+        text="Kennisclips"
       />
     </li>
     <li>
@@ -266,13 +266,13 @@
       transform: translateX(0);
     }
 
-    ul li:nth-of-type(6) {
+    ul li:nth-of-type(7) {
       grid-column-start: 3;
       grid-row-start: 3;
       transform: translateX(0);
     }
 
-    ul li:nth-of-type(7) {
+    ul li:nth-of-type(6) {
       grid-column-start: 2;
       grid-row-start: 3;
       transform: translateX(0);
@@ -283,7 +283,5 @@
       grid-row-start: 3;
       transform: translateX(0);
     }
-
-   
   }
 </style>

--- a/src/lib/organisms/miniCourses.svelte
+++ b/src/lib/organisms/miniCourses.svelte
@@ -69,7 +69,7 @@
   }
 
   ul li:nth-of-type(4) {
-    --background-color: var(--vtDarkBlue);
+    --background-color: var(--vtSec-DarkBlue);
   }
 
   @media (width > 36rem) {


### PR DESCRIPTION
# Description
Please include a summary of the changes and the related issue(s).  
Please include relevant motivation and context, with a screenshot if necessary.  
Please include a link to the live site, where the change is implemented.  

Doordat de hexagons met een clippath gemaakt zijn was de uitlijning van de focus state met het tabben niet te zien. 
Heb daarom de focus state veranderd van een outline naar een scale van 1.05.
Na het zien van de order van de homepage met de keyboard test was de volgorder heel vaag hiervan, vooral bij de desktop variant. Deze volgorder van de desktop variant is nu gefixed.

Heb ook de blauwe kleur van de minicourse pagina veranderd van --vtDark-Blue naar --vtSec-Dark-Blue om dit meer een geheel te maken met de huisstijl van de homepagina.

Fixes #253

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Responsive Design test
> De tab order was eerst ook raar bij de homepage, maar is nu gefixed!!

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] The code is accessible
- [x] The code is performant
- [x] The code is responsive
- [ ] I have written meaningful commit messages
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README and/or Wiki)



