### PR TITLE
[Feature] #507 Refactor artikelen pages for Directus migration

### DIFF
--- a/src/lib/organisms/Articles.svelte
+++ b/src/lib/organisms/Articles.svelte
@@ -6,12 +6,14 @@
   {#each articles as article}
     <a href="/artikelen/{article.slug}">
       <article>
-        <img
-          src={article.visual.url}
-          alt={article.title}
-          width="200"
-          height="200"
-        />
+        {#if article.visual?.url}
+          <img
+            src={article.visual.url}
+            alt={article.title}
+            width="200"
+            height="200"
+          />
+        {/if}
         <h2>{article.title}</h2>
       </article>
     </a>

--- a/src/lib/utils/directus.js
+++ b/src/lib/utils/directus.js
@@ -1,9 +1,9 @@
 import { createDirectus, graphql } from "@directus/sdk";
 import { DIRECTUS_URL } from "$env/static/private";
 
-const url = DIRECTUS_URL; 
+const url = DIRECTUS_URL;
 
-if (url == undefined || url.length === 0) {
+if (url === undefined || url.length === 0) {
     throw new Error("Directus url is empty or undefined");
 }
 

--- a/src/routes/artikelen/+page.server.js
+++ b/src/routes/artikelen/+page.server.js
@@ -1,27 +1,39 @@
-import { gql } from "graphql-request";
-import { hygraph } from "$lib/utils/hygraph.js";
+import { directus } from "$lib/utils/directus.js";
+import { DIRECTUS_URL } from "$env/static/private";
 
 export async function load() {
-  let query = gql`
+  const query = `
     query Articles {
-      page(where: {id: "clv8dqjvwum6i07w4u8fwvnsu"}) {
+      adconnect_artikelen_page {
         title
-        content {
-          html
-        }
+        content
       }
       
-      articles(first:6) {
-        visual {
-          url
-        }
+      adconnect_artikel(limit: 6) {
         title
         intro
         slug
+        visual {
+          id
+        }
       }
     }
   `;
-  const data = await hygraph.request(query);
-  
-  return data
+
+  let data;
+  try {
+    data = await directus.query(query);
+  } catch (error) {
+    console.error("Error loading articles page:", error);
+    console.error("Error details:", JSON.stringify(error.errors, null, 2));
+    throw error;
+  }
+
+  const page = data.adconnect_artikelen_page;
+  const articles = data.adconnect_artikel.map(article => ({
+    ...article,
+    visual: article.visual ? { url: `${DIRECTUS_URL}/assets/${article.visual.id}` } : null
+  }));
+
+  return { page, articles };
 }

--- a/src/routes/artikelen/+page.server.js
+++ b/src/routes/artikelen/+page.server.js
@@ -7,14 +7,13 @@ export async function load() {
       adconnect_artikelen_page {
         title
         content
-      }
-      
-      adconnect_artikel(limit: 6) {
-        title
-        intro
-        slug
-        visual {
-          id
+        artikelen(limit: 6) {
+          title
+          intro
+          slug
+          visual {
+            id
+          }
         }
       }
     }
@@ -30,7 +29,7 @@ export async function load() {
   }
 
   const page = data.adconnect_artikelen_page;
-  const articles = data.adconnect_artikel.map(article => ({
+  const articles = (page?.artikelen || []).map(article => ({
     ...article,
     visual: article.visual ? { url: `${DIRECTUS_URL}/assets/${article.visual.id}` } : null
   }));

--- a/src/routes/artikelen/[slug]/+page.server.js
+++ b/src/routes/artikelen/[slug]/+page.server.js
@@ -1,11 +1,12 @@
 import { directus } from "$lib/utils/directus.js";
 import { DIRECTUS_URL } from "$env/static/private";
+import { error } from "@sveltejs/kit";
 
 export const load = async ({ params }) => {
   const { slug } = params;
   const query = `
-    query Article {
-      adconnect_artikel(filter: { slug: { _eq: "${slug}" } }) {
+    query Article($slug: String!) {
+      adconnect_artikel(filter: { slug: { _eq: $slug } }) {
         title
         intro
         slug
@@ -19,17 +20,17 @@ export const load = async ({ params }) => {
 
   let data;
   try {
-    data = await directus.query(query);
-  } catch (error) {
-    console.error("Error loading article:", error);
-    console.error("GraphQL errors:", JSON.stringify(error.errors, null, 2));
-    throw error;
+    data = await directus.query(query, { slug });
+  } catch (err) {
+    console.error("Error loading article:", err);
+    console.error("GraphQL errors:", JSON.stringify(err.errors, null, 2));
+    throw err;
   }
 
   const articleData = data.adconnect_artikel[0];
 
   if (!articleData) {
-    throw new Error("Article not found");
+    error(404, "Article not found");
   }
 
   const article = {

--- a/src/routes/artikelen/[slug]/+page.server.js
+++ b/src/routes/artikelen/[slug]/+page.server.js
@@ -1,24 +1,41 @@
-import { gql } from "graphql-request";
-import { hygraph } from "$lib/utils/hygraph.js";
-
+import { directus } from "$lib/utils/directus.js";
+import { DIRECTUS_URL } from "$env/static/private";
 
 export const load = async ({ params }) => {
-	const { slug } = params;
-	const query = gql`
+  const { slug } = params;
+  const query = `
     query Article {
-      article(where: { slug: "${slug}"}) {
-        visual {
-          url
-        }
+      adconnect_artikel(filter: { slug: { _eq: "${slug}" } }) {
         title
         intro
         slug
-        content {
-            html
+        content
+        visual {
+          id
         }
       }
     }
   `;
 
-    return await hygraph.request(query);
+  let data;
+  try {
+    data = await directus.query(query);
+  } catch (error) {
+    console.error("Error loading article:", error);
+    console.error("GraphQL errors:", JSON.stringify(error.errors, null, 2));
+    throw error;
+  }
+
+  const articleData = data.adconnect_artikel[0];
+
+  if (!articleData) {
+    throw new Error("Article not found");
+  }
+
+  const article = {
+    ...articleData,
+    visual: articleData.visual ? { url: `${DIRECTUS_URL}/assets/${articleData.visual.id}` } : null
+  };
+
+  return { article };
 }

--- a/src/routes/artikelen/[slug]/+page.svelte
+++ b/src/routes/artikelen/[slug]/+page.svelte
@@ -22,7 +22,7 @@
 </header>
 
 <div class="content">
-  {#if visual.url} 
+  {#if visual?.url} 
     <img src="{visual.url}" alt="{title}" />
   {/if}
   
@@ -32,7 +32,7 @@
   </p>
 
   <div class="rich-text">
-    {@html content.html}
+    {@html content}
   </div> 
   
 </div>


### PR DESCRIPTION
## Summary
This PR updates the artikelen section to use Directus instead of Hygraph and improves rendering safety across the articles pages.

## Changes
- Migrated `src/routes/artikelen/+page.server.js` to fetch the artikelen page and article list from Directus
- Migrated `src/routes/artikelen/[slug]/+page.server.js` to fetch individual article data from Directus
- Updated article image handling to build Directus asset URLs
- Added safer image rendering checks in `Articles.svelte` and `[slug]/+page.svelte`
