### PR TITLE
switch artikelen to vt_artikel & vt_artikelen_page closes #507

### DIFF
--- a/src/lib/molecules/Introduction.svelte
+++ b/src/lib/molecules/Introduction.svelte
@@ -16,24 +16,24 @@
   h1 {
     font-size: 1.7rem;
   }
-  
+
   @media screen and (min-width: 36rem) {
     section {
-          max-width: 75%;
-      }
-      h1 {
-          font-size: 3.157rem;
-          text-align: center;
-      }
+      max-width: 75%;
+    }
+    h1 {
+      font-size: 3.157rem;
+      text-align: center;
+    }
   }
 
   @media screen and (min-width: 60rem) {
     section {
-          max-width: 32rem;
-      }
-      h1 {
-          font-size: 3.157rem;
-          text-align: center;
-      }
+      max-width: 32rem;
+    }
+    h1 {
+      font-size: 3.157rem;
+      text-align: center;
+    }
   }
 </style>

--- a/src/lib/molecules/Introduction.svelte
+++ b/src/lib/molecules/Introduction.svelte
@@ -1,12 +1,10 @@
 <script>
   let { page } = $props();
-  const {title, content} = page;
-
 </script>
 
 <section class="intro">
-  <h1>{title}</h1>
-  {@html content}
+  <h1>{page.titel}</h1>
+  {@html page.beschrijving}
 </section>
 
 <style>

--- a/src/lib/organisms/Articles.svelte
+++ b/src/lib/organisms/Articles.svelte
@@ -6,15 +6,15 @@
   {#each articles as article}
     <a href="/artikelen/{article.slug}">
       <article>
-        {#if article.visual?.url}
+        {#if article.visueel?.url}
           <img
-            src={article.visual.url}
-            alt={article.title}
+            src={article.visueel.url}
+            alt={article.titel}
             width="200"
             height="200"
           />
         {/if}
-        <h2>{article.title}</h2>
+        <h2>{article.titel}</h2>
       </article>
     </a>
   {/each}

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -7,8 +7,8 @@ export async function load() {
         const data = await directus.query(`
             query homePage {
                 adconnect_homepage {
-                    title
-                    content
+                    titel: title
+                    beschrijving: content
                 }
             }`);
         return data;

--- a/src/routes/artikelen/+page.server.js
+++ b/src/routes/artikelen/+page.server.js
@@ -6,7 +6,7 @@ export async function load() {
     query Articles {
       vt_artikelen_page {
         titel
-        beschrijving: inhoud
+        inhoud
         artikelen(limit: 6) {
           titel
           intro

--- a/src/routes/artikelen/+page.server.js
+++ b/src/routes/artikelen/+page.server.js
@@ -5,13 +5,13 @@ export async function load() {
   const query = `
     query Articles {
       vt_artikelen_page {
-        title: titel
-        content: inhoud
+        titel
+        beschrijving: inhoud
         artikelen(limit: 6) {
-          title: titel
+          titel
           intro
           slug
-          visual: visueel {
+          visueel {
             id
           }
         }
@@ -31,7 +31,7 @@ export async function load() {
   const page = data.vt_artikelen_page;
   const articles = (page?.artikelen || []).map(article => ({
     ...article,
-    visual: article.visual ? { url: `${DIRECTUS_URL}/assets/${article.visual.id}` } : null
+    visueel: article.visueel ? { url: `${DIRECTUS_URL}/assets/${article.visueel.id}` } : null
   }));
 
   return { page, articles };

--- a/src/routes/artikelen/+page.server.js
+++ b/src/routes/artikelen/+page.server.js
@@ -4,14 +4,14 @@ import { DIRECTUS_URL } from "$env/static/private";
 export async function load() {
   const query = `
     query Articles {
-      adconnect_artikelen_page {
-        title
-        content
+      vt_artikelen_page {
+        title: titel
+        content: inhoud
         artikelen(limit: 6) {
-          title
+          title: titel
           intro
           slug
-          visual {
+          visual: visueel {
             id
           }
         }
@@ -28,7 +28,7 @@ export async function load() {
     throw error;
   }
 
-  const page = data.adconnect_artikelen_page;
+  const page = data.vt_artikelen_page;
   const articles = (page?.artikelen || []).map(article => ({
     ...article,
     visual: article.visual ? { url: `${DIRECTUS_URL}/assets/${article.visual.id}` } : null

--- a/src/routes/artikelen/[slug]/+page.server.js
+++ b/src/routes/artikelen/[slug]/+page.server.js
@@ -10,7 +10,7 @@ export const load = async ({ params }) => {
         titel
         intro
         slug
-        beschrijving: inhoud
+        inhoud
         visueel {
           id
         }

--- a/src/routes/artikelen/[slug]/+page.server.js
+++ b/src/routes/artikelen/[slug]/+page.server.js
@@ -6,12 +6,12 @@ export const load = async ({ params }) => {
   const { slug } = params;
   const query = `
     query Article($slug: String!) {
-      adconnect_artikel(filter: { slug: { _eq: $slug } }) {
-        title
+      vt_artikel(filter: { slug: { _eq: $slug } }) {
+        title: titel
         intro
         slug
-        content
-        visual {
+        content: inhoud
+        visual: visueel {
           id
         }
       }
@@ -27,7 +27,7 @@ export const load = async ({ params }) => {
     throw err;
   }
 
-  const articleData = data.adconnect_artikel[0];
+  const articleData = data.vt_artikel[0];
 
   if (!articleData) {
     error(404, "Article not found");

--- a/src/routes/artikelen/[slug]/+page.server.js
+++ b/src/routes/artikelen/[slug]/+page.server.js
@@ -7,11 +7,11 @@ export const load = async ({ params }) => {
   const query = `
     query Article($slug: String!) {
       vt_artikel(filter: { slug: { _eq: $slug } }) {
-        title: titel
+        titel
         intro
         slug
-        content: inhoud
-        visual: visueel {
+        beschrijving: inhoud
+        visueel {
           id
         }
       }
@@ -35,7 +35,7 @@ export const load = async ({ params }) => {
 
   const article = {
     ...articleData,
-    visual: articleData.visual ? { url: `${DIRECTUS_URL}/assets/${articleData.visual.id}` } : null
+    visueel: articleData.visueel ? { url: `${DIRECTUS_URL}/assets/${articleData.visueel.id}` } : null
   };
 
   return { article };

--- a/src/routes/artikelen/[slug]/+page.svelte
+++ b/src/routes/artikelen/[slug]/+page.svelte
@@ -3,18 +3,22 @@
 
   let { data } = $props();
 
-  const {titel, visueel, intro, beschrijving} = data.article
+  const { titel, visueel, intro, inhoud } = data.article;
 </script>
 
-<Breadcrumb titel="Overzicht" url="/artikelen" backgroundColor="var(--color-tertiary)" />
+<Breadcrumb
+  titel="Overzicht"
+  url="/artikelen"
+  backgroundColor="var(--color-tertiary)"
+/>
 
 <header>
   <div>
-    <p>Gepost op <time>26 maart 2019<time></p>
+    <p>Gepost op <time>26 maart 2019<time></time></time></p>
   </div>
 
   <h1>{titel}</h1>
-  
+
   <ul>
     <li><a href="/">Creatief denken</a></li>
     <li><a href="/">Onderwijs</a></li>
@@ -22,19 +26,17 @@
 </header>
 
 <div class="content">
-  {#if visueel?.url} 
-    <img src="{visueel.url}" alt="{titel}" />
+  {#if visueel?.url}
+    <img src={visueel.url} alt={titel} />
   {/if}
-  
 
   <p class="intro">
     {intro}
   </p>
 
   <div class="rich-text">
-    {@html beschrijving}
-  </div> 
-  
+    {@html inhoud}
+  </div>
 </div>
 
 <style>
@@ -51,26 +53,25 @@
   }
   header > ul {
     grid-column: 2 / -1;
-    display:flex;
+    display: flex;
     padding-left: 0;
-    list-style:none;
-    gap:1rem;
-    
+    list-style: none;
+    gap: 1rem;
   }
   header > ul li {
     background-color: var(--color-quinary);
   }
   header > ul li a {
     text-decoration: none;
-    padding:.5rem;
-    color:inherit
+    padding: 0.5rem;
+    color: inherit;
   }
   header p {
     font-size: 1rem;
     font-family: var(--font-family-secondary);
     line-height: 1.5rem;
     color: var(--color-tertiary);
-    margin:0;
+    margin: 0;
   }
 
   time {
@@ -80,37 +81,37 @@
   /* tablet */
   @media (min-width: 50em) {
     header {
-      display:grid;
+      display: grid;
       grid-template-columns: 20rem 10fr;
-      gap:0 2rem;
+      gap: 0 2rem;
       background-color: var(--color-septenary-40);
-      padding:2rem 0 0;
+      padding: 2rem 0 0;
       margin: 0 -1rem 2rem;
     }
     header > div {
-      padding:0 2rem;
-      align-self:flex-end;
-      border-right:1px solid var(--color-septenary);
-      text-align:right;
-      flex-shrink:0;
+      padding: 0 2rem;
+      align-self: flex-end;
+      border-right: 1px solid var(--color-septenary);
+      text-align: right;
+      flex-shrink: 0;
     }
     header > div p {
-      margin:0;
+      margin: 0;
     }
     header > div p * {
       font-weight: bold;
-      display:block;
-      color: var(--color-tertiary)
+      display: block;
+      color: var(--color-tertiary);
     }
     header h1 {
-      align-self:flex-end;
-      margin:0
+      align-self: flex-end;
+      margin: 0;
     }
-    
+
     div.content {
-      padding-left:20rem;
-      padding-right:2rem;
-      max-width:50em;
+      padding-left: 20rem;
+      padding-right: 2rem;
+      max-width: 50em;
     }
   }
 

--- a/src/routes/artikelen/[slug]/+page.svelte
+++ b/src/routes/artikelen/[slug]/+page.svelte
@@ -3,7 +3,7 @@
 
   let { data } = $props();
 
-  const {title, visual, intro, content} = data.article
+  const {titel, visueel, intro, beschrijving} = data.article
 </script>
 
 <Breadcrumb titel="Overzicht" url="/artikelen" backgroundColor="var(--color-tertiary)" />
@@ -13,7 +13,7 @@
     <p>Gepost op <time>26 maart 2019<time></p>
   </div>
 
-  <h1>{title}</h1>
+  <h1>{titel}</h1>
   
   <ul>
     <li><a href="/">Creatief denken</a></li>
@@ -22,8 +22,8 @@
 </header>
 
 <div class="content">
-  {#if visual?.url} 
-    <img src="{visual.url}" alt="{title}" />
+  {#if visueel?.url} 
+    <img src="{visueel.url}" alt="{titel}" />
   {/if}
   
 
@@ -32,7 +32,7 @@
   </p>
 
   <div class="rich-text">
-    {@html content}
+    {@html beschrijving}
   </div> 
   
 </div>


### PR DESCRIPTION
## Description
Updated the GraphQL queries for the Artikelen page to match the new Directus schema naming.  Replaced the old collection names, and updated the field names to the Dutch naming convention using GraphQL  aliases to keep the existing component structure intact. Closes #507