### PR TITLE
Materials and Categories GraphQL query fix

### DIFF
--- a/src/lib/molecules/MethodTags.svelte
+++ b/src/lib/molecules/MethodTags.svelte
@@ -9,17 +9,16 @@
     <IconCategories />
     <div>
       {#each categories as category}
-        <p>{category.titel}</p>
+        <p>{category}</p>
       {/each}
     </div>
   </li>
   <!-- Materials Section -->
   <li>
     <IconMaterials />
-
     {#each materials as material}
       <div>
-        <p>{material.titel}</p>
+        <p>{material}</p>
       </div>
     {/each}
   </li>

--- a/src/lib/molecules/Steps.svelte
+++ b/src/lib/molecules/Steps.svelte
@@ -16,8 +16,6 @@
               loading="lazy"
             />
           {/each}
-        {:else}
-          <p>Geen visualisaties</p>
         {/if}
         {@html step?.beschrijving}
       </div>

--- a/src/lib/molecules/Steps.svelte
+++ b/src/lib/molecules/Steps.svelte
@@ -7,8 +7,8 @@
     <details open={stepIndex === 0}>
       <summary>{step.titel}</summary>
       <div>
-        {#if step?.visualisaties?.length > 0}
-          {#each step.visualisaties as visual}
+        {#if step?.visuals?.length > 0}
+          {#each step.visuals as visual}
             <img
               class="carrousel-img"
               src={visual?.url}

--- a/src/routes/tekenmethodes/[slug]/stappenplan/+page.server.js
+++ b/src/routes/tekenmethodes/[slug]/stappenplan/+page.server.js
@@ -15,6 +15,7 @@ export const load = async ({ params }) => {
             id
           }
           stappen {
+            id
             titel
             beschrijving
             visualisaties {
@@ -78,11 +79,13 @@ export const load = async ({ params }) => {
     materialen: (
       catMatData?.vt_tekenmethodes_vt_tekenmethodes_materialen || []
     ).map((item) => ({ titel: item?.vt_tekenmethodes_materialen_id?.titel })),
-    stappen: (method?.stappen || []).map((stap) => ({
-      ...stap,
-      visualisaties: (stap?.visualisaties || []).map((visual) => ({
-        url: `${DIRECTUS_URL}/assets/${visual.directus_files_id.id}`,
-      })),
-    })),
+    stappen: (method?.stappen || [])
+      .map((stap) => ({
+        ...stap,
+        visualisaties: (stap?.visualisaties || []).map((visual) => ({
+          url: `${DIRECTUS_URL}/assets/${visual.directus_files_id.id}`,
+        })),
+      }))
+      .sort((a, b) => a.id - b.id),
   };
 };

--- a/src/routes/tekenmethodes/[slug]/stappenplan/+page.server.js
+++ b/src/routes/tekenmethodes/[slug]/stappenplan/+page.server.js
@@ -44,28 +44,39 @@ export const load = async ({ params }) => {
 
   let method;
   let catMatData;
-  
+
   try {
     const data = await directus.query(query, { slug });
-    method = data?.vt_tekenmethodes?.[0];
-    if (!method) throw error(404, "Tekenmethode niet gevonden")
-
-    catMatData = await directus.query(categoriesMaterialsQuery, { methodId: method.id });
-    if (!catMatData) throw error(404, "materialen en categorieen niet gevonden")
-
   } catch (error) {
-    console.error("Error loading stappenplan:", error);
+    console.error("Error loading method data:", error);
     console.error("Error details:", JSON.stringify(error.errors, null, 2));
     throw error;
   }
 
+  method = data?.vt_tekenmethodes?.[0];
+  if (!method) throw error(404, "Tekenmethode niet gevonden");
+
+  try {
+    catMatData = await directus.query(categoriesMaterialsQuery, {
+      methodId: method.id,
+    });
+  } catch (error) {
+    console.error("Error loading materials and categories:", error);
+    console.error("Error details:", JSON.stringify(error.errors, null, 2));
+    throw error;
+  }
+
+  if (!catMatData) throw error(404, "materialen en categorieen niet gevonden");
+
   return {
     ...method,
     pdf: method.pdf ? { url: `${DIRECTUS_URL}/assets/${method.pdf.id}` } : null,
-    categorieen: (catMatData?.vt_tekenmethodes_vt_categorieen || [])
-      .map((item) => ({ titel: item?.vt_categorieen_id?.titel })),
-    materialen: (catMatData?.vt_tekenmethodes_vt_tekenmethodes_materialen || [])
-      .map((item) => ({ titel: item?.vt_tekenmethodes_materialen_id?.titel })),
+    categorieen: (catMatData?.vt_tekenmethodes_vt_categorieen || []).map(
+      (item) => ({ titel: item?.vt_categorieen_id?.titel })
+    ),
+    materialen: (
+      catMatData?.vt_tekenmethodes_vt_tekenmethodes_materialen || []
+    ).map((item) => ({ titel: item?.vt_tekenmethodes_materialen_id?.titel })),
     stappen: (method?.stappen || []).map((stap) => ({
       ...stap,
       visualisaties: (stap?.visualisaties || []).map((visual) => ({

--- a/src/routes/tekenmethodes/[slug]/stappenplan/+page.server.js
+++ b/src/routes/tekenmethodes/[slug]/stappenplan/+page.server.js
@@ -42,11 +42,12 @@ export const load = async ({ params }) => {
       }
     `;
 
+  let data;
   let method;
   let catMatData;
 
   try {
-    const data = await directus.query(query, { slug });
+    data = await directus.query(query, { slug });
   } catch (error) {
     console.error("Error loading method data:", error);
     console.error("Error details:", JSON.stringify(error.errors, null, 2));

--- a/src/routes/tekenmethodes/[slug]/stappenplan/+page.server.js
+++ b/src/routes/tekenmethodes/[slug]/stappenplan/+page.server.js
@@ -24,6 +24,7 @@ export const load = async ({ params }) => {
             }
           }
           stappen {
+            id
             titel
             beschrijving
             visualisaties {
@@ -55,11 +56,13 @@ export const load = async ({ params }) => {
     materials: method.materialen.map(
       (mat) => mat.vt_tekenmethodes_materialen_id.titel
     ),
-    steps: (method?.stappen || []).map((stap) => ({
-      ...stap,
-      visuals: (stap?.visualisaties || []).map((visual) => ({
-        url: `${DIRECTUS_URL}/assets/${visual.directus_files_id.id}`,
-      })),
-    })),
+    steps: (method?.stappen || [])
+      .map((stap) => ({
+        ...stap,
+        visuals: (stap?.visualisaties || []).map((visual) => ({
+          url: `${DIRECTUS_URL}/assets/${visual.directus_files_id.id}`,
+        })),
+      }))
+      .sort((a, b) => a.id - b.id),
   };
 };

--- a/src/routes/tekenmethodes/[slug]/stappenplan/+page.server.js
+++ b/src/routes/tekenmethodes/[slug]/stappenplan/+page.server.js
@@ -8,16 +8,11 @@ export const load = async ({ params }) => {
       query Stappen($slug: String!) {
         vt_tekenmethodes(filter: { slug: { _eq: $slug } }) {
           titel
+          id
           slug
           duur
           pdf {
             id
-          }
-          categorieen {
-            titel
-          }
-          materialen {
-            titel
           }
           stappen {
             titel
@@ -32,21 +27,45 @@ export const load = async ({ params }) => {
       }
     `;
 
-  let data;
+  const categoriesMaterialsQuery = `
+      query TekenmethodeCategoriesMaterials($methodId: GraphQLStringOrFloat) {
+        vt_tekenmethodes_vt_categorieen(filter: { vt_tekenmethodes_id: { id: { _eq: $methodId } } }) {
+          vt_categorieen_id {
+            titel
+          }
+        }
+        vt_tekenmethodes_vt_tekenmethodes_materialen(filter: { vt_tekenmethodes_id: { id: { _eq: $methodId } } }) {
+          vt_tekenmethodes_materialen_id {
+            titel
+          }
+        }
+      }
+    `;
+
+  let method;
+  let catMatData;
+  
   try {
-    data = await directus.query(query, { slug });
+    const data = await directus.query(query, { slug });
+    method = data?.vt_tekenmethodes?.[0];
+    if (!method) throw error(404, "Tekenmethode niet gevonden")
+
+    catMatData = await directus.query(categoriesMaterialsQuery, { methodId: method.id });
+    if (!catMatData) throw error(404, "materialen en categorieen niet gevonden")
+
   } catch (error) {
     console.error("Error loading stappenplan:", error);
     console.error("Error details:", JSON.stringify(error.errors, null, 2));
     throw error;
   }
 
-  const method = data?.vt_tekenmethodes?.[0];
-  if (!method) throw error(404, "Tekenmethode niet gevonden");
-
   return {
     ...method,
     pdf: method.pdf ? { url: `${DIRECTUS_URL}/assets/${method.pdf.id}` } : null,
+    categorieen: (catMatData?.vt_tekenmethodes_vt_categorieen || [])
+      .map((item) => ({ titel: item?.vt_categorieen_id?.titel })),
+    materialen: (catMatData?.vt_tekenmethodes_vt_tekenmethodes_materialen || [])
+      .map((item) => ({ titel: item?.vt_tekenmethodes_materialen_id?.titel })),
     stappen: (method?.stappen || []).map((stap) => ({
       ...stap,
       visualisaties: (stap?.visualisaties || []).map((visual) => ({

--- a/src/routes/tekenmethodes/[slug]/stappenplan/+page.server.js
+++ b/src/routes/tekenmethodes/[slug]/stappenplan/+page.server.js
@@ -8,14 +8,22 @@ export const load = async ({ params }) => {
       query Stappen($slug: String!) {
         vt_tekenmethodes(filter: { slug: { _eq: $slug } }) {
           titel
-          id
           slug
           duur
           pdf {
             id
           }
+          categorieen {
+            vt_categorieen_id {
+              titel
+            }
+          }
+          materialen {
+            vt_tekenmethodes_materialen_id {
+              titel
+            }
+          }
           stappen {
-            id
             titel
             beschrijving
             visualisaties {
@@ -28,64 +36,30 @@ export const load = async ({ params }) => {
       }
     `;
 
-  const categoriesMaterialsQuery = `
-      query TekenmethodeCategoriesMaterials($methodId: GraphQLStringOrFloat) {
-        vt_tekenmethodes_vt_categorieen(filter: { vt_tekenmethodes_id: { id: { _eq: $methodId } } }) {
-          vt_categorieen_id {
-            titel
-          }
-        }
-        vt_tekenmethodes_vt_tekenmethodes_materialen(filter: { vt_tekenmethodes_id: { id: { _eq: $methodId } } }) {
-          vt_tekenmethodes_materialen_id {
-            titel
-          }
-        }
-      }
-    `;
-
   let data;
-  let method;
-  let catMatData;
-
   try {
     data = await directus.query(query, { slug });
   } catch (error) {
-    console.error("Error loading method data:", error);
+    console.error("Error loading stappenplan:", error);
     console.error("Error details:", JSON.stringify(error.errors, null, 2));
     throw error;
   }
 
-  method = data?.vt_tekenmethodes?.[0];
+  const method = data?.vt_tekenmethodes?.[0];
   if (!method) throw error(404, "Tekenmethode niet gevonden");
-
-  try {
-    catMatData = await directus.query(categoriesMaterialsQuery, {
-      methodId: method.id,
-    });
-  } catch (error) {
-    console.error("Error loading materials and categories:", error);
-    console.error("Error details:", JSON.stringify(error.errors, null, 2));
-    throw error;
-  }
-
-  if (!catMatData) throw error(404, "materialen en categorieen niet gevonden");
 
   return {
     ...method,
     pdf: method.pdf ? { url: `${DIRECTUS_URL}/assets/${method.pdf.id}` } : null,
-    categorieen: (catMatData?.vt_tekenmethodes_vt_categorieen || []).map(
-      (item) => ({ titel: item?.vt_categorieen_id?.titel })
+    categories: method.categorieen.map((cat) => cat.vt_categorieen_id.titel),
+    materials: method.materialen.map(
+      (mat) => mat.vt_tekenmethodes_materialen_id.titel
     ),
-    materialen: (
-      catMatData?.vt_tekenmethodes_vt_tekenmethodes_materialen || []
-    ).map((item) => ({ titel: item?.vt_tekenmethodes_materialen_id?.titel })),
-    stappen: (method?.stappen || [])
-      .map((stap) => ({
-        ...stap,
-        visualisaties: (stap?.visualisaties || []).map((visual) => ({
-          url: `${DIRECTUS_URL}/assets/${visual.directus_files_id.id}`,
-        })),
-      }))
-      .sort((a, b) => a.id - b.id),
+    steps: (method?.stappen || []).map((stap) => ({
+      ...stap,
+      visuals: (stap?.visualisaties || []).map((visual) => ({
+        url: `${DIRECTUS_URL}/assets/${visual.directus_files_id.id}`,
+      })),
+    })),
   };
 };

--- a/src/routes/tekenmethodes/[slug]/stappenplan/+page.svelte
+++ b/src/routes/tekenmethodes/[slug]/stappenplan/+page.svelte
@@ -2,7 +2,7 @@
   import { Breadcrumb, MethodHeader, MethodTags, Steps } from "$lib/index.js";
 
   let { data } = $props();
-  const { titel, slug, pdf, duur, stappen, categorieen, materialen } = data;
+  const { titel, slug, pdf, duur, steps, categories, materials } = data;
 </script>
 
 <Breadcrumb
@@ -14,12 +14,12 @@
 <section>
   <div class="sticky">
     <MethodTags
-      categories={categorieen}
+      {categories}
       duration={duur}
-      materials={materialen}
+      {materials}
     />
   </div>
-  <Steps steps={stappen} />
+  <Steps {steps} />
 </section>
 
 <style>


### PR DESCRIPTION
Fixes # (issue)
Due to the change in the relationship from o2m to m2m between the drawing method, categories, and materials collections in Directus, the previous GraphQL query is no longer operational.

- Fixes the stappenplan query by adding vt_tekenmethodes_materialen_id and vt_categorieen_id fields corresponding to the junction table, thus enabling m2m relationship
- the phrase 'geen voorbeelden' is removed, so there is no placeholder text when there is no image, thus the state of things is reversed back as it is in the 'main' branch now
- sort is added to the 'steps', based on ID, which keeps the order of insertion since the steps' IDs are sequential integers; otherwise, the steps become shuffled after getting from the Directus
- Refactoring the components, affected by renaming Dutch to English of the fields that were mutated after fetching from Directus, as required by the naming convention.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] User test
- [ ] Accessibility test
- [ ] Performance test
- [x] Responsive Design test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] The code is accessible
- [ ] The code is performant
- [x] The code is responsive
- [ ] I have written meaningful commit messages
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README and/or Wiki)



