### PR TITLE
Feature minicursussesn directus migration #502

### DIFF
--- a/test/cms/e2e/minicursus.monkey.spec.js
+++ b/test/cms/e2e/minicursus.monkey.spec.js
@@ -16,6 +16,9 @@ test('minicursus monkey test: overview -> detail -> carousel navigation', async 
   await expect(page).toHaveURL(/\/minicursussen\/.+/);
   await expect(page.locator('.carousel')).toBeVisible();
 
+  // Wait for the page to hydrate before interacting: the carousel buttons are
+  await page.waitForLoadState('networkidle');
+
   const slides = page.locator('article.slide');
   await expect(slides.first()).toBeVisible();
   // The detail page renders slide headings rather than a visible header title.

--- a/test/cms/e2e/minicursus.monkey.spec.js
+++ b/test/cms/e2e/minicursus.monkey.spec.js
@@ -1,0 +1,46 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+test('minicursus monkey test: overview -> detail -> carousel navigation', async ({ page }) => {
+  // Arrange: pick a random course from the overview
+  await page.goto('/minicursussen');
+  const courseLinks = page.locator('a.course-card');
+  await expect(courseLinks.first()).toBeVisible();
+  const courseCount = await courseLinks.count();
+  const randomCourse = courseLinks.nth(Math.floor(Math.random() * courseCount));
+
+  // Act: navigate to the course detail page
+  await randomCourse.click();
+
+  // Assert: detail page loaded with the correct URL, carousel, and slides
+  await expect(page).toHaveURL(/\/minicursussen\/.+/);
+  await expect(page.locator('.carousel')).toBeVisible();
+
+  const slides = page.locator('article.slide');
+  await expect(slides.first()).toBeVisible();
+  // The detail page renders slide headings rather than a visible header title.
+  await expect(slides.first().locator('h2')).toBeVisible();
+  const slideCount = await slides.count();
+  expect(slideCount).toBeGreaterThan(0);
+
+  if (slideCount > 1) {
+    // Arrange: locate the carousel and its navigation buttons
+    const carousel = page.locator('.carousel');
+    const nextButton = page.locator('button.scroll-btn.next');
+    const prevButton = page.locator('button.scroll-btn.prev');
+    await expect(nextButton).toBeVisible();
+    await expect(prevButton).toBeVisible();
+
+    // Act: navigate to the next slide
+    await nextButton.click();
+
+    // Assert: carousel scrolled forward off the first slide
+    await expect.poll(() => carousel.evaluate((el) => el.scrollLeft)).toBeGreaterThan(0);
+
+    // Act: navigate back to the first slide
+    await prevButton.click();
+
+    // Assert: carousel scrolled back to the start
+    await expect.poll(() => carousel.evaluate((el) => el.scrollLeft)).toBe(0);
+  }
+});

--- a/test/cms/e2e/minicursus.spec.js
+++ b/test/cms/e2e/minicursus.spec.js
@@ -12,7 +12,6 @@ test("minicursus overview page displays courses", async ({ page }) => {
   const courseCount = await courseCards.count();
 
   expect(courseCount).toBeGreaterThan(0);
-  await expect(page).toHaveTitle("Visual Thinking");
 });
 
 test("minicursus detail shows first slide heading", async ({ page }) => {
@@ -21,8 +20,6 @@ test("minicursus detail shows first slide heading", async ({ page }) => {
   await page.goto(`/minicursussen/${slug}`);
 
   // Detail pages render slide headings rather than a visible `h1` title.
-  await expect(page).toHaveTitle("Visual Thinking");
-
   const firstSlideHeading = page.getByRole("heading", { name: "Introductie" });
   await expect(firstSlideHeading).toBeVisible();
 });

--- a/test/cms/e2e/minicursus.spec.js
+++ b/test/cms/e2e/minicursus.spec.js
@@ -1,0 +1,43 @@
+// @ts-check
+import { test, expect } from "@playwright/test";
+
+test("minicursus overview page displays courses", async ({ page }) => {
+  await page.goto("/minicursussen");
+
+  const h1 = page.locator("h1");
+  await expect(h1).toBeVisible();
+
+  // Check that course cards are rendered
+  const courseCards = page.locator(".course-card");
+  const courseCount = await courseCards.count();
+
+  expect(courseCount).toBeGreaterThan(0);
+  await expect(page).toHaveTitle("Visual Thinking");
+});
+
+test("minicursus detail shows first slide heading", async ({ page }) => {
+  const slug = "basisvormen";
+
+  await page.goto(`/minicursussen/${slug}`);
+
+  // Detail pages render slide headings rather than a visible `h1` title.
+  await expect(page).toHaveTitle("Visual Thinking");
+
+  const firstSlideHeading = page.getByRole("heading", { name: "Introductie" });
+  await expect(firstSlideHeading).toBeVisible();
+});
+
+test("minicursus slides are visible and navigable", async ({ page }) => {
+  const slug = "basisvormen";
+
+  await page.goto(`/minicursussen/${slug}`);
+
+  // Check that slides container exists
+  const slidesContainer = page.locator(".carousel");
+  await expect(slidesContainer).toBeVisible();
+
+  // Check for slide content
+  const slideContent = page.locator("article.slide");
+  const slideCount = await slideContent.count();
+  expect(slideCount).toBeGreaterThan(0);
+});

--- a/test/cms/minicursus.test.js
+++ b/test/cms/minicursus.test.js
@@ -1,22 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { directusMiniCursusSlugQuery, hygraphMiniCursusSlugQuery, directusMiniCursusesQuery, hygraphMiniCursusesQuery } from "./queries/minicursus";
+import {
+  directusMiniCursusSlugQuery,
+  hygraphMiniCursusSlugQuery,
+} from "./queries/minicursus";
 import { directus } from "./directus";
 import z, { json } from "zod";
-import { directusMiniCursusOutputSchema, directusMiniCursusesOutputSchema, directusMinicursusSlideOutputSchema } from "./schemas/minicursus_schema";
+import {
+  directusMiniCursusOutputSchema, 
+} from "./schemas/minicursus_schema";
 import { hygraph } from "./hygraph";
 import * as cheerio from "cheerio";
 import { normalizeHtml } from "./helpers/normalizeHtml";
 
 describe("testing minicursus fetching data", () => {
- 
   const slug = ["basisvormen"];
   const directusInstance = directus;
   const schema = directusMiniCursusOutputSchema;
 
   it("Should fetch data for a particular minicursus and not error", async () => {
-    const slugQuery = directusMiniCursusSlugQuery;
-
-    const response = await directusInstance.query(directusMiniCursusSlugQuery(slug[0]),);
+    const response = await directusInstance.query(directusMiniCursusSlugQuery(slug[0]));
     const minicursus = response.vt_minicursussen[0];
     schema.parse(minicursus);
 
@@ -26,43 +28,31 @@ describe("testing minicursus fetching data", () => {
     expect(minicursus.slides[0]?.titel).toBeTypeOf("string");
   });
 
-  it("Should be the same data in Hygraph and Directus for minicursuses", async () => {
-    const hygraphQuery = hygraphMiniCursusesQuery;
-    const directusMiniCursusesListQuery = directusMiniCursusesQuery;
+  it("Should have matching slide data (count, title, content) for the minicursus", async () => {
+    const [directusCourseResponse, hygraphCourseResponse] = await Promise.all([
+      directusInstance.query(directusMiniCursusSlugQuery(slug[0])),
+      hygraph.request(hygraphMiniCursusSlugQuery(slug[0])),
+    ]);
 
-    // We fetch both from Hygraph and Directus
-    const [directusResponse, hygraphResponse] = await Promise.all([directusInstance.query(directusMiniCursusesListQuery), hygraph.request(hygraphQuery),]);
+    const directusCourse = directusCourseResponse.vt_minicursussen[0];
+    const hygraphCourse = hygraphCourseResponse.miniCourse;
 
-    // normalize data: titel to title, slug to slug, 
-    const normalizedHygraphContent = hygraphResponse.miniCourses.map((c) => ({
-      title: c.title,
-      slug: c.slug,
-    }));
-    const normalizedDirectusContent = directusResponse.vt_minicursussen.map((c) => ({
-      ...c,
-      title: c.titel,
-  }));
+    // Course title should match
+    expect(directusCourse.titel).toEqual(hygraphCourse.title);
 
-    const directusMap = new Map(
-      normalizedDirectusContent.map((course) => [
-        course.slug,
-        course
-      ])
-    );
-    const hygraphMap = new Map(
-      normalizedHygraphContent.map((course) => [
-        course.slug,
-        course
-      ])
-    );
+    // Same number of slides
+    expect(directusCourse.slides.length).toEqual(hygraphCourse.slides.length);
 
-    // Assert all fields are equal.
-    for (const [slug, directusMiniCursus] of directusMap) {
-      const hygraphMiniCursus = hygraphMap.get(slug);
+    // Compare each slide, matched by position in the array
+    directusCourse.slides.forEach((directusSlide, index) => {
+      const hygraphSlide = hygraphCourse.slides[index];
 
-      expect(hygraphMiniCursus).toBeDefined();
-      expect(hygraphMiniCursus.title).toEqual(directusMiniCursus.title);
-      expect(hygraphMiniCursus.slug).toEqual(directusMiniCursus.slug);
-    }
+      expect(directusSlide.titel).toEqual(hygraphSlide.title);
+
+      const directusContent = normalizeHtml(directusSlide.inhoud ?? "");
+      const hygraphContent = normalizeHtml(hygraphSlide.content.html ?? "");
+
+      expect(directusContent).toEqual(hygraphContent);
+    });
   });
 });

--- a/test/cms/minicursus.test.js
+++ b/test/cms/minicursus.test.js
@@ -16,9 +16,9 @@ describe("testing minicursus fetching data", () => {
   it("Should fetch data for a particular minicursus and not error", async () => {
     const slugQuery = directusMiniCursusSlugQuery;
 
-    const response = await directus.query(directusMiniCursusSlugQuery(slug[0]),);
+    const response = await directusInstance.query(directusMiniCursusSlugQuery(slug[0]),);
     const minicursus = response.vt_minicursussen[0];
-    directusMiniCursusOutputSchema.parse(minicursus);
+    schema.parse(minicursus);
 
     expect(minicursus.titel).toBeTypeOf("string");
     expect(minicursus.slug).toBeTypeOf("string");
@@ -31,9 +31,9 @@ describe("testing minicursus fetching data", () => {
     const directusMiniCursusesListQuery = directusMiniCursusesQuery;
 
     // We fetch both from Hygraph and Directus
-    const [directusResponse, hygraphResponse] = await Promise.all([directus.query(directusMiniCursusesListQuery), hygraph.request(hygraphQuery),]);
+    const [directusResponse, hygraphResponse] = await Promise.all([directusInstance.query(directusMiniCursusesListQuery), hygraph.request(hygraphQuery),]);
 
-    // normalize both the rich text field since Directus and Hygraph store rich text differently
+    // normalize data: titel to title, slug to slug, 
     const normalizedHygraphContent = hygraphResponse.miniCourses.map((c) => ({
       title: c.title,
       slug: c.slug,

--- a/test/cms/minicursus.test.js
+++ b/test/cms/minicursus.test.js
@@ -9,14 +9,14 @@ import { normalizeHtml } from "./helpers/normalizeHtml";
 
 describe("testing minicursus fetching data", () => {
  
-  const slugs = ["basisvormen", "handlettering"];
+  const slug = ["basisvormen"];
   const directusInstance = directus;
   const schema = directusMiniCursusOutputSchema;
 
   it("Should fetch data for a particular minicursus and not error", async () => {
     const slugQuery = directusMiniCursusSlugQuery;
 
-    const response = await directus.query(directusMiniCursusSlugQuery(slugs[0]),);
+    const response = await directus.query(directusMiniCursusSlugQuery(slug[0]),);
     const minicursus = response.vt_minicursussen[0];
     directusMiniCursusOutputSchema.parse(minicursus);
 

--- a/test/cms/minicursus.test.js
+++ b/test/cms/minicursus.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { directusMiniCursusSlugQuery, hygraphMiniCursusSlugQuery, directusMiniCursusesQuery, hygraphMiniCursusesQuery } from "./queries/minicursus";
+import { directus } from "./directus";
+import z, { json } from "zod";
+import { directusMiniCursusOutputSchema, directusMiniCursusesOutputSchema, directusMinicursusSlideOutputSchema } from "./schemas/minicursus_schema";
+import { hygraph } from "./hygraph";
+import * as cheerio from "cheerio";
+import { normalizeHtml } from "./helpers/normalizeHtml";
+
+describe("testing minicursus fetching data", () => {
+ 
+  const slugs = ["basisvormen", "handlettering"];
+  const directusInstance = directus;
+  const schema = directusMiniCursusOutputSchema;
+
+  it("Should fetch data for a particular minicursus and not error", async () => {
+    const slugQuery = directusMiniCursusSlugQuery;
+
+    const response = await directus.query(directusMiniCursusSlugQuery(slugs[0]),);
+    const minicursus = response.vt_minicursussen[0];
+    directusMiniCursusOutputSchema.parse(minicursus);
+
+    expect(minicursus.titel).toBeTypeOf("string");
+    expect(minicursus.slug).toBeTypeOf("string");
+    expect(Array.isArray(minicursus.slides)).toBe(true);
+    expect(minicursus.slides[0]?.titel).toBeTypeOf("string");
+  });
+
+  it("Should be the same data in Hygraph and Directus for minicursuses", async () => {
+    const hygraphQuery = hygraphMiniCursusesQuery;
+    const directusMiniCursusesListQuery = directusMiniCursusesQuery;
+
+    // We fetch both from Hygraph and Directus
+    const [directusResponse, hygraphResponse] = await Promise.all([directus.query(directusMiniCursusesListQuery), hygraph.request(hygraphQuery),]);
+
+    // normalize both the rich text field since Directus and Hygraph store rich text differently
+    const normalizedHygraphContent = hygraphResponse.miniCourses.map((c) => ({
+      title: c.title,
+      slug: c.slug,
+    }));
+    const normalizedDirectusContent = directusResponse.vt_minicursussen.map((c) => ({
+      ...c,
+      title: c.titel,
+  }));
+
+    const directusMap = new Map(
+      normalizedDirectusContent.map((course) => [
+        course.slug,
+        course
+      ])
+    );
+    const hygraphMap = new Map(
+      normalizedHygraphContent.map((course) => [
+        course.slug,
+        course
+      ])
+    );
+
+    // Assert all fields are equal.
+    for (const [slug, directusMiniCursus] of directusMap) {
+      const hygraphMiniCursus = hygraphMap.get(slug);
+
+      expect(hygraphMiniCursus).toBeDefined();
+      expect(hygraphMiniCursus.title).toEqual(directusMiniCursus.title);
+      expect(hygraphMiniCursus.slug).toEqual(directusMiniCursus.slug);
+    }
+  });
+});

--- a/test/cms/queries/minicursus.js
+++ b/test/cms/queries/minicursus.js
@@ -1,0 +1,65 @@
+export const directusMiniCursusSlugQuery = (slug) => `
+      query MiniCourse {
+        vt_minicursussen(filter: { slug: { _eq: "${slug}" } }) {
+          slug
+          titel
+          slides {
+            titel
+            inhoud
+            afbeelding {
+              id
+            }
+          }
+        }
+      }
+    `;
+
+export const directusMiniCursusesQuery = `
+      query minicursus_page {
+        vt_minicursussen_page {
+          titel
+          beschrijving
+        }
+          
+        vt_minicursussen {
+          titel
+          slug
+          afbeelding {
+            id
+          }
+        }
+      }
+    `;
+
+export const hygraphMiniCursusSlugQuery = (slug) => `
+    query MiniCourse {
+      miniCourse(where: {slug: "${slug}"}) {
+        title
+        slides {
+          title
+          content {
+            html
+          }
+          image {
+            url
+          }
+        }
+      }
+    }
+  `;
+
+export const hygraphMiniCursusesQuery = `
+    query MiniCourses {
+      page(where: {id: "clv8eb8jmw1hv07uncpsrut9l"}) {
+        title
+        content {
+          html
+        }
+      }
+
+      miniCourses {
+        title
+        slug
+      }
+    }
+  `;

--- a/test/cms/schemas/minicursus_schema.js
+++ b/test/cms/schemas/minicursus_schema.js
@@ -1,0 +1,30 @@
+import z from "zod";
+
+
+export const directusMinicursusSlideOutputSchema = z.object({
+  titel: z.string(),
+  inhoud: z.string(),
+  afbeelding: z
+    .object({
+      id: z.string(),
+    })
+    .optional()
+    .nullable(),
+});
+
+export const directusMiniCursusOutputSchema = z.object({
+  slug: z.string(),
+  titel: z.string(),
+  slides: z.array(directusMinicursusSlideOutputSchema),
+});
+
+export const directusMiniCursusesOutputSchema = z.object({
+  titel: z.string(),
+  afbeelding: z
+    .object({
+      id: z.string(),
+    })
+    .optional()
+    .nullable(),
+  minicursussen: z.array(directusMiniCursusOutputSchema),
+});


### PR DESCRIPTION
Description
This PR holds tests that checks the minicursussen data in both Hygraph and Directus. It also has end-to-end tests which verify the course cards are being displayed, confirms a minicursus has slides and stores a heading, and checks if the slides amount is greater then 0